### PR TITLE
Metadata for iterated type

### DIFF
--- a/parametrica/abc/field.py
+++ b/parametrica/abc/field.py
@@ -210,10 +210,15 @@ class ABCField(Generic[T]):
                 'password': self.__password__
             }
         else:
+            if self.__is_iterable_type__():
+                field_instance = self.__generic_type__()()
+            else:
+                field_instance = self.__get__(instance, instance.__class__)
+
             return {
                 'is_primitive': False,
                 'is_iterable': self.__is_iterable_type__(),
-                'type': self.__get__(instance, instance.__class__).__metadata__(instance),
+                'type': field_instance.__metadata__(instance),
                 # 'default': self.__get_default__(instance).__metadata__(instance),
                 'name': self.__name__,
                 'label': self.__label__,


### PR DESCRIPTION
Если сделать конфиг на подобие такого, в котором есть итерируемый тип, внутри которого в свою очередь лежит не примитив, а наследник от класса `Fieldset`
```python
from typing import List
from parametrica import Field, Fieldset, Parametrica
from parametrica.io import YAMLFileConfigIO

class Child(Fieldset):
    field1 = Field[str]('')
    fieldtoo = Field[int](0)

class Parent(Fieldset):
    children = Field[List[Child]]([
        Child(field1='value1', fieldtoo=2)
    ])

class Config(Parametrica):
    data = Field[Parent]().label('todo')

config = Config(YAMLFileConfigIO('config.yaml'))
```

То получаем ошибку следующего типа
```log
Traceback (most recent call last):
  File "main.py", line 11, in <module>
    main()
  File "main.py", line 7, in main
    print(config.__metadata__())
  File "C:\dev\parametrica\parametrica\abc\fieldset.py", line 175, in __metadata__
    metadata[field_name] = field.__metadata__(self)
  File "C:\dev\parametrica\parametrica\abc\field.py", line 216, in __metadata__
    'type': self.__get__(instance, instance.__class__).__metadata__(instance),
  File "C:\dev\parametrica\parametrica\abc\fieldset.py", line 138, in __metadata__
    metadata[field_name] = field.__metadata__(self)
  File "C:\dev\parametrica\parametrica\abc\field.py", line 216, in __metadata__
    'type': self.__get__(instance, instance.__class__).__metadata__(instance),
AttributeError: 'tuple' object has no attribute '__metadata__'
```

Проблема была в том, что для получения метаданных не примитивного типа берется уже само значение поля (либо дефолтное, либо текущее из конфига), но для итерируемого типа возвращался именно список или кортеж, у которого нет метода `__metadata__`. Ведь там же список хранится внутри поля, значит и вернет он тоже список.
Таких проблем нет для списков, внутри которых лежат примитивные типы, т.к. с ними нет необходимости вызывать метадату.

Проблему решил костылем: если мы смотрим для не примитивного типа, и он является итерируемым, то берем его generic тип, инициализируем его и уже у него вызываем `__metadata__`.

Возможны проблемы, если этот generic тип будет требовать в себя какие-то параметры при инициализации, но, как я понял, все такие поля это наследники от класса `Fieldset`, а значит не будут в себе иметь инициализации по каким-то параметрам, иначе вообще ничего не запустится