### PR TITLE
Fix regex for make comment

### DIFF
--- a/parametrica/io.py
+++ b/parametrica/io.py
@@ -107,13 +107,13 @@ class YAMLFileConfigIO(FileConfigIOInterface):
             if field.__label__ == '' and field.__hint__ == '':
                 continue
             if parent_fieldset == '':
-                search = re.compile(rf'.*?(\n|^)({field_name}):', re.S)
+                search = re.compile(rf'.*?(?:\n|^)({field_name}):', re.S)
             else:
-                search = re.compile(rf'.*?(\n|^) {{{indent-2}}}{parent_fieldset}:.*?\n {{{indent}}}({field_name}):', re.S)
+                search = re.compile(rf'.*?(?:\n|^) {{{indent-2}}}{parent_fieldset}:.*?\n {{{indent}}}({field_name}):', re.S)
             match = search.match(resultstr)
             if match:
-                if len(match.regs) > 2:
-                    pos = match.regs[2][0]
+                if len(match.regs) > 1:
+                    pos = match.regs[1][0]
                     if field.__is_primitive_type__():
                         comment = ''
                         comment += field.__label__.replace("\n"," ").replace("\r", " ") + " " if field.__label__ else ''

--- a/parametrica/io.py
+++ b/parametrica/io.py
@@ -107,13 +107,13 @@ class YAMLFileConfigIO(FileConfigIOInterface):
             if field.__label__ == '' and field.__hint__ == '':
                 continue
             if parent_fieldset == '':
-                search = re.compile(r'\A.*{}({})\:'.format(indent*" ", field_name), re.RegexFlag.S)
+                search = re.compile(rf'.*?(\n|^)({field_name}):', re.S)
             else:
-                search = re.compile(r'\A.*{}{}\:.*?{}({})\:'.format((indent-2)*" ", parent_fieldset, indent*" ", field_name), re.RegexFlag.S)
+                search = re.compile(rf'.*?(\n|^) {{{indent-2}}}{parent_fieldset}:.*? {{{indent}}}({field_name}):', re.S)
             match = search.match(resultstr)
             if match:
-                if len(match.regs) > 1:
-                    pos = match.regs[1][0]
+                if len(match.regs) > 2:
+                    pos = match.regs[2][0]
                     if field.__is_primitive_type__():
                         comment = ''
                         comment += field.__label__.replace("\n"," ").replace("\r", " ") + " " if field.__label__ else ''

--- a/parametrica/io.py
+++ b/parametrica/io.py
@@ -109,7 +109,7 @@ class YAMLFileConfigIO(FileConfigIOInterface):
             if parent_fieldset == '':
                 search = re.compile(rf'.*?(\n|^)({field_name}):', re.S)
             else:
-                search = re.compile(rf'.*?(\n|^) {{{indent-2}}}{parent_fieldset}:.*? {{{indent}}}({field_name}):', re.S)
+                search = re.compile(rf'.*?(\n|^) {{{indent-2}}}{parent_fieldset}:.*?\n {{{indent}}}({field_name}):', re.S)
             match = search.match(resultstr)
             if match:
                 if len(match.regs) > 2:


### PR DESCRIPTION
В ишуе про баг с добавлением комментария #7 описана проблема, когда есть поля, с одинаковыми именами в полях (хотя бы частично), то создание комментариев работает некорректно и выдает невалидный YAML.

Проблема была в поиске поля по регулярке, эту регулярку и исправил, переделав ее, теперь создание комментариев работает с описанной в вопросе конфигурацией и схожими без проблем. Все тесты также пройдены.