### PR TITLE
Possible fix for files with only zero bytes

### DIFF
--- a/parametrica/io.py
+++ b/parametrica/io.py
@@ -50,12 +50,26 @@ class FileConfigIOInterface(ConfigIOInterface):
         
     def write(self, dataset: dict):
         serialized = self.serialize(dataset)
-        fd = os.open(self.edit_filename, os.O_WRONLY|os.O_CREAT)
-        os.write(fd, serialized.encode(encoding="utf-8"))
+
+        # Write data to edit file
+        fd = os.open(self.edit_filename, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+        writed_bytes = os.write(fd, serialized.encode(encoding="utf-8"))
+        if writed_bytes == 0 and serialized != '':
+            raise IOError(f'0 bytes were written to the file {self.edit_filename}')
         os.fsync(fd)
         os.close(fd)
 
+        # Replace original file with edit file
         os.replace(self.edit_filename, self.filename)
+
+        # Write new file on disk
+        containing_dir = os.path.dirname(self.filename) or '.'
+        dir_fd = os.open(containing_dir, os.O_DIRECTORY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+
 
 
 class VirtualFile(FileConfigIOInterface):

--- a/parametrica/io.py
+++ b/parametrica/io.py
@@ -50,14 +50,13 @@ class FileConfigIOInterface(ConfigIOInterface):
         
     def write(self, dataset: dict):
         serialized = self.serialize(dataset)
-
-        with open(self.edit_filename, 'w+', encoding='utf-8') as f:
-            f.write(serialized)
-            f.close()
+        fd = os.open(self.edit_filename, os.O_WRONLY|os.O_CREAT)
+        os.write(fd, serialized.encode(encoding="utf-8"))
+        os.fsync(fd)
+        os.close(fd)
 
         os.replace(self.edit_filename, self.filename)
-        
-            
+
 
 class VirtualFile(FileConfigIOInterface):
 

--- a/parametrica/io.py
+++ b/parametrica/io.py
@@ -62,15 +62,6 @@ class FileConfigIOInterface(ConfigIOInterface):
         # Replace original file with edit file
         os.replace(self.edit_filename, self.filename)
 
-        # Write new file on disk
-        containing_dir = os.path.dirname(self.filename) or '.'
-        dir_fd = os.open(containing_dir, os.O_DIRECTORY)
-        try:
-            os.fsync(dir_fd)
-        finally:
-            os.close(dir_fd)
-
-
 
 class VirtualFile(FileConfigIOInterface):
 

--- a/parametrica/io.py
+++ b/parametrica/io.py
@@ -50,14 +50,20 @@ class FileConfigIOInterface(ConfigIOInterface):
         
     def write(self, dataset: dict):
         serialized = self.serialize(dataset)
+        serialized_bytes_like = serialized.encode(encoding='utf-8')
 
         # Write data to edit file
-        fd = os.open(self.edit_filename, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
-        writed_bytes = os.write(fd, serialized.encode(encoding="utf-8"))
-        if writed_bytes == 0 and serialized != '':
-            raise IOError(f'0 bytes were written to the file {self.edit_filename}')
-        os.fsync(fd)
-        os.close(fd)
+        fd = os.open(self.edit_filename, os.O_WRONLY | os.O_CREAT, 0o644)
+        try:
+            writed_bytes = os.write(fd, serialized_bytes_like)
+            if writed_bytes == 0 and serialized != '':
+                raise IOError(f'0 bytes were written to the file {self.edit_filename}')
+            elif writed_bytes != len(serialized_bytes_like):
+                raise IOError(f'Instead of the expected {len(serialized_bytes_like)} bytes, {writed_bytes} bytes were written to the file {self.edit_filename}')
+            os.fsync(fd)
+
+        finally:
+            os.close(fd)
 
         # Replace original file with edit file
         os.replace(self.edit_filename, self.filename)


### PR DESCRIPTION
# Проблема
При записи данных в файл был шанс, что все байты файла станул нулевыми (`0x00000`), при этом само количество байт сохранялось. Баг случался рандомно, однако его удалось воспроизвести с помощью многопроцессорности.

Если запустить несколько процессов, которые одовременно стартуют и пытаются перезаписать файл, то чаще всего он как раз таки занулялся. Но случаться могло и не только в случае с несколькими процессами.

# Гипотеза
## Немного теории о буферах
Запись данных в файл через python происходит не сразу на физический диск, особенно, если использовать стандартную высокоуровневую функцию `open()`. 

Данные для записи в файл проходят через несколько буферов:
```
Код Python
       |
Буфер Python (userspace) - open() управляет этим уровнем
       |
Страничный кэш ОС (page cache) - ядро Linux/Windows/macOS
       |
Аппаратный кэш диска (write cache контроллера/HDD/SSD)
       |
Физический носитель (диск)
```

При использовании `f.write()` данные сначала попадают в буфер Python и будут храниться там, пока не случится одно из:
- не будет вызван `f.flush()`;
- файл не будет закрыт;
- буфер Python не будет заполнен *(обычно он на 8 кб)*.

После буфера Python файл попадает в статичный кэш, откуда уже будет записан на диск. И тут может возникнуть проблема, т.к. ядро асинхронно сбрасывает кэш **раз в 30 секунд** в фоновом режиме.

> Если файл видно в проводнике, терминале или других программах, то это еще не значит, что он уже на диске. Современные ОС всегда предоставляют только интерфейс для работы с файлами и часто могут подкидывать кэш программам со всеми метаданными. Это отдельная тема про разделения видимости данных и их долговечности.

Далее идет аппаратный кэш диска. Как правило, все современный SSD имеют свой кэш памяти. Как уже работает он зависит от конкретного диска.

Эти буферы существуют ради оптимизации скорости записи данных в файлы и существуют более чем оправданно. Есть статейка, где один парень проверял скорость записи с буферами и без буферов (как раз на Python). Результат хороший, с буферами 7 миллионов записей в секунду, а без всего 4000 в секунду. Ссылочку прилагаю:

https://medium.com/@raaj.akshar/balancing-performance-and-durability-an-experiment-in-file-writing-with-python-59856c4e1b2d

## Уязвимость буферов
Пока данные файла находятся в этих кэшах, они не попадают на диск, а значит если произойдет сбой и, например, у ПК отключиться питание, то данные будут утеряны **безвозвратно**.

> Мне рассказывали, что с занулением файлов встречались, когда ПК отключали от питания.

Я уверен на 95%, что всегда была проблема именно в этом - потери данных в буферах. Но почему баг воспроизводится при нескольких процессах, я сказать уверенно не могу.

# Решение
Чтобы решить проблему необходимо обойти все буферы и кэши и заставить ОС записать файл на диск. Мы потеряем в скорости, но для записи файла конфига это неважно, куда важнее целостность данных. Для этого в Python существуют инструменты.

Я предлагаю 2 основных идеи

## Библиотека os вместо open()
Запись в файл не через высокоуровневую функцию `open()`, а через низкоуровневую библиотеку `os`, которая позволит нам обойти буфер Python.

## Использование os.fsync()
Использование функции `os.fsync()`, которая говорит операционной системе записать файл из кэша на диск. Но все еще есть кэш аппаратный кэш диска. Как обойти его, я найти не смог.

<hr>

Т.к. библиотека `os` низкоуровневая, то с ней могут потенциально возникнуть проблемы из-за неправильного использования. Но я постарался исключить все возможные проблемы:
- Пишу изменения в файл `.edit`, чтобы в случае проблем не потерять основной файл;
- Использую `os.O_WRONLY | os.O_CREAT | os.O_EXCL`, для атомарной записи файлов и отсутствия гонки данных;
- Проверяю количество записанных байт в файл. Если ничего не записалось, то у нас все еще есть оригинальный файл;
- `os.replace()` не зменяет файлы, а заменят лишь ссылки на разные ноды диска. Если ПК отключат от питания, то у нас все еще останется файл, т.к. он уже был записан на диск *(конечно, если не пошло что-то не так на аппаратном кэше)*.

Это должно гарантировать максимальную надежность записи файлов на диск. Возможно чего-то лишнего нагородил, можно использовать и обычный `open()` вместе с `os.fsync()`, но я художник, я так вижу.









